### PR TITLE
Use lowercase sirupsen/logrus dependency

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/labstack/echo"
 	"github.com/labstack/gommon/log"
 )


### PR DESCRIPTION
This fixes projects that depends on the lowercase [sirupsen/logrus](https://github.com/sirupsen/logrus) repo. See [this issue](https://github.com/sirupsen/logrus/issues/543).

This will fix dependency resolution on Glide that depends on this middleware.