### PR TITLE
Lowercase logrus import as per logrus instructions

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/labstack/echo"
 	"github.com/labstack/gommon/log"
 )


### PR DESCRIPTION
Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.
From
https://github.com/sirupsen/logrus