### PR TITLE
Fix sandalwing/echo-logrusmiddleware#3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ go get github.com/sandalwing/echo-logrusmiddleware
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/labstack/echo"
 	"github.com/sandalwing/echo-logrusmiddleware"
 )

--- a/middleware.go
+++ b/middleware.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/labstack/echo"
 	"github.com/labstack/gommon/log"
+	"github.com/sirupsen/logrus"
 )
 
 type Logger struct {


### PR DESCRIPTION
As per https://github.com/sirupsen/logrus:

> Seeing weird case-sensitive problems? It's in the past been possible
> to import Logrus as both upper- and lower-case. Due to the Go package
> environment, this caused issues in the community and we needed a
> standard. Some environments experienced problems with the upper-case
> variant, so the lower-case was decided. Everything using logrus will
> need to use the lower-case: github.com/sirupsen/logrus. Any package that
> isn't, should be changed.