### PR TITLE
fix logrus import

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/labstack/echo"
 	"github.com/labstack/gommon/log"
 )


### PR DESCRIPTION
This PR updates logrus import to the lowercase one.
> Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.